### PR TITLE
draggable bookmarklet: working

### DIFF
--- a/components/bookmarklet.tsx
+++ b/components/bookmarklet.tsx
@@ -1,22 +1,24 @@
-export const BookmarkletComponent = () => {
+"use client";
 
-    const handleDragStart = (event: { dataTransfer: { setData: (arg0: string, arg1: string) => void; }; }) => {
-        event.dataTransfer.setData('text/plain', "javascript:(function(){window.location.href='https://smry.ai/'+window.location.href;})();");
-      };
+export const BookmarkletComponent = () => {
+  const bookmarklet = `javascript:(function(){
+    window.location.href='https://smry.ai/' + window.location.href;
+  })();`;
+
   return (
-    <section className="hidden sm:block relative z-0 mt-16 bg-stone-50 rounded-xl border  border-zinc-200 hover:bg-black transition-all duration-500"
-    aria-hidden="true"
-    onDragStart={handleDragStart}
-    draggable="true"
-    aria-label="Drag this to your bookmarks bar for quick summaries"
+    <section
+      className="hidden sm:block relative z-0 mt-16 bg-stone-50 rounded-xl border border-zinc-200 transition-all duration-500"
+      aria-label="Drag this to your bookmarks bar for quick summaries"
     >
-      <div className="w-full max-w-5xl mx-auto px-4 md:px-6 py-4 rounded-xl">
+      <div className="w-full max-w-5xl mx-auto px-4 md:px-6 py-6 rounded-xl">
         <div className="text-center">
-          <div
-            className="flex flex-col lg:flex-row space-y-4 lg:space-y-0 lg:space-x-4 items-center justify-center text-xl sm:text-2xl md:text-3xl font-semibold text-slate-900 hover:text-white before:absolute before:inset-0 before:rounded-xl hover:before:bg-black before:-z-10 before:transition-colors before:duration-500 group"
+          <a
+            href={bookmarklet}
+            className="flex flex-col lg:flex-row space-y-4 lg:space-y-0 lg:space-x-4 items-center justify-center text-xl sm:text-2xl md:text-3xl font-semibold text-slate-900 hover:text-white relative group"
+            title="Drag me to your bookmarks bar"
           >
             <span className="relative p-0.5 rounded-full bg-slate-200 group-hover:bg-zinc-700 transition duration-500 overflow-hidden flex items-center justify-center before:opacity-0 group-hover:before:opacity-100 before:absolute before:w-1/3 before:pb-[100%] before:rounded-full before:bg-[linear-gradient(90deg,_theme(colors.indigo.500/0)_0%,_theme(colors.indigo.500)_35%,_theme(colors.indigo.200)_50%,_theme(colors.indigo.500)_65%,_theme(colors.indigo.500/0)_100%)] before:animate-[spin_3s_linear_infinite]">
-              <span className="relative whitespace-nowrap ">
+              <span className="relative whitespace-nowrap">
                 <span className="block px-6 py-4 rounded-full bg-gradient-to-r from-slate-200 to-slate-100 z-10 group-hover:opacity-0 transition-opacity duration-500 ease-in-out">
                   Quick Summarize
                 </span>
@@ -29,7 +31,7 @@ export const BookmarkletComponent = () => {
             <span className="group-hover:text-slate-300 transition-colors duration-500 ease-in-out">
               with smry.ai
             </span>
-          </div>
+          </a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Earlier implementation of the bookmarklet feature was just a draggable section, but dragging it won’t actually create a bookmark in the browser. 

Browsers only let users create bookmarks if the thing being dragged is a valid ```<a href="javascript:...">``` link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced the draggable bookmarklet widget with a simple clickable link that opens smry.ai with the current page, removing drag-and-drop behavior while keeping overall functionality intact.

* **Style**
  * Updated spacing (increased padding), streamlined layout, and added a subtle gradient overlay for a cleaner look.
  * Clarified labels (“Quick Summarize” with smry.ai) and removed unnecessary attributes to improve accessibility and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->